### PR TITLE
Made http/https port configurable by generating /etc/org.ops4j.pax.web.cfg file containing default value of 8080/8443

### DIFF
--- a/distributions/base/src/main/karaf/assembly-property-edits.xml
+++ b/distributions/base/src/main/karaf/assembly-property-edits.xml
@@ -25,5 +25,17 @@
       <key>org.ops4j.pax.url.mvn.repositories</key>
       <value>http://oss.jfrog.org/artifactory/simple/libs-snapshot@id=ojo-libs-snapshot@snapshots@noreleases</value>
     </edit>
+    <edit>
+      <file>org.ops4j.pax.web.cfg</file>
+      <operation>put</operation>
+      <key>org.osgi.service.http.port</key>
+      <value>8080</value>
+    </edit>
+    <edit>
+      <file>org.ops4j.pax.web.cfg</file>
+      <operation>put</operation>
+      <key>org.osgi.service.http.port.secure</key>
+      <value>8443</value>
+    </edit>
   </edits>
 </property-edits>


### PR DESCRIPTION
Made http/https port configurable by generating /etc/org.ops4j.pax.web.cfg file containing default value of 8080/8443

Signed-off-by: Satish Nikam satniks@gmail.com
